### PR TITLE
fix a syntax error axP -> xaP :/

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,6 @@ before_install:
 
 script:
  - planemo lint ${TRAVIS_BUILD_DIR}/galaxy/probmetab
- - planemo test --conda_auto_init --conda_auto_install --conda_dependency_resolution --galaxy_branch release_17.01 --no_cache_galaxy ${TRAVIS_BUILD_DIR}/galaxy/probmetab
+ - travis_wait 40 planemo test --conda_auto_init --conda_auto_install --conda_dependency_resolution --galaxy_branch release_17.01 --no_cache_galaxy ${TRAVIS_BUILD_DIR}/galaxy/probmetab
 
 

--- a/galaxy/probmetab/lib.r
+++ b/galaxy/probmetab/lib.r
@@ -50,8 +50,8 @@ probmetab = function(xa, xaP, xaN, variableMetadata, variableMetadataP, variable
         #}
         # include CAMERA non-annotated compounds, and snr retrieval
         # comb 2+ - used on Table 1
-        ionAnnotP2plus = get.annot(axP, allowMiss=listArguments[["allowMiss"]], xset=xsetPnofill,toexclude=listArguments[["toexclude"]])
-        ionAnnotN2plus = get.annot(axN, polarity="negative", allowMiss=listArguments[["allowMiss"]], xset=xsetNnofill,toexclude=listArguments[["toexclude"]])
+        ionAnnotP2plus = get.annot(xaP, allowMiss=listArguments[["allowMiss"]], xset=xsetPnofill,toexclude=listArguments[["toexclude"]])
+        ionAnnotN2plus = get.annot(xaN, polarity="negative", allowMiss=listArguments[["allowMiss"]], xset=xsetNnofill,toexclude=listArguments[["toexclude"]])
         ionAnnot = combineMolIon(ionAnnotP2plus, ionAnnotN2plus)
         print(sum(ionAnnot$molIon[,3]==1))
         print(sum(ionAnnot$molIon[,3]==0))


### PR DESCRIPTION
When using two acquisition modes:
```
Error in as.matrix(xsAnnotate@isoID) : object 'axP' not found
Calls: probmetab -> get.annot -> as.matrix
Execution halted
```